### PR TITLE
Fix AppMenu active elements

### DIFF
--- a/viv-wallet-app/src/App.vue
+++ b/viv-wallet-app/src/App.vue
@@ -10,9 +10,9 @@
             <div class="root">
                 <div class="menu">
                     <Banner></Banner>
-                    <router-link to="/">Home</router-link>
-                    <router-link to="/users">Users</router-link>
-                    <router-link to="/wallet">Wallet</router-link>
+                    <custom-router-link to="/">Home</custom-router-link>
+                    <custom-router-link to="/users">Users</custom-router-link>
+                    <custom-router-link to="/wallet">Wallet</custom-router-link>
                 </div>
                 <div class="content">
                     <router-view />
@@ -28,8 +28,9 @@ import "x4b-ui/dist/x4b-ui/x4b-ui.css";
 import { getToken, login } from "x4b-ui";
 import { LOGIN_URL, APPS_URL } from "./config/constants";
 import { version } from "../package.json";
+import CustomRouterLink from "./components/CustomRouterLink.vue";
 
-@Component({ components: { Banner } })
+@Component({ components: { Banner, CustomRouterLink } })
 export default class App extends Vue {
     private appsUrl: string = APPS_URL;
     private appVersion: string = version;
@@ -85,6 +86,7 @@ body {
     flex-direction: column;
     color: $white;
     text-align: left;
+    width: 155px;
     a {
         padding: $m-3 $m-7 $m-3 $m-6;
         color: $primary-200;
@@ -99,7 +101,7 @@ body {
     }
 }
 
-a.router-link-exact-active {
+a.router-link-active {
     background-color: $primary-600;
     color: $white;
     font-weight: 600;

--- a/viv-wallet-app/src/components/CustomRouterLink.vue
+++ b/viv-wallet-app/src/components/CustomRouterLink.vue
@@ -1,0 +1,23 @@
+<template>
+    <router-link :to="to" v-slot="{ route, href, navigate }">
+        <a
+            :href="href"
+            @click="navigate"
+            :class="route.path === $route.path ? 'router-link-active' : ''"
+            :aria-current="route.path === $route.path && route.path"
+        >
+            <slot></slot>
+        </a>
+    </router-link>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from "vue-property-decorator";
+
+@Component
+export default class CustomRouterLink extends Vue {
+    @Prop() to!: string;
+}
+</script>
+
+<style />


### PR DESCRIPTION
As the Url can contain query parameters such as the auth token, it breaks the active style of the links.
Currently, there is no native fix available in Vue.js yet.
I applied the following fix: [https://github.com/vuejs/vue-router/issues/2040](https://github.com/vuejs/vue-router/issues/2040).