### PR TITLE
[Circle CI] improve performance of the helm chart job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 orbs:
-    azure-aks: circleci/azure-aks@0.2.0
     azure-cli: circleci/azure-cli@1.1.0
     helm: circleci/helm@0.2.3
+    docker: circleci/docker@1.5.0
 
 references:
     job_filters_tags_and_branches: &job_filters_tags_and_branches
@@ -148,12 +148,13 @@ jobs:
                       fi
 
     helm_chart:
-        executor: azure-aks/default
+        executor: azure-cli/azure-docker
         resource_class: small
         steps:
             - checkout
             - attach_workspace:
                   at: /home/circleci/project
+            - docker/install-docker
             - helm/install-helm-client:
                   version: v3.1.1
             - *build_version_variables
@@ -174,7 +175,6 @@ jobs:
                       fi
             - setup_remote_docker:
                   docker_layer_caching: false
-            - azure-cli/install
             - azure-cli/login-with-user-or-service-principal
             - run:
                   name: Publish chart

--- a/viv-wallet-app/package.json
+++ b/viv-wallet-app/package.json
@@ -6,7 +6,7 @@
         "serve": "vue-cli-service serve",
         "serve:localbackend": "vue-cli-service serve --mode localbackend",
         "build": "vue-cli-service build",
-        "test:unit": "vue-cli-service test:unit",
+        "test:unit": "vue-cli-service test:unit --runInBand",
         "lint": "vue-cli-service lint --max-warnings 0",
         "typecheck": "./node_modules/.bin/tsc --noEmit",
         "mock-server": "json-server --watch mock-server.json --routes mock-server-routes.json",


### PR DESCRIPTION
- It's the same fix I made in the other X4B repositories.
- Remove the azure-cli:install step, which takes so much time
- Use a pre-installed version of the Azure CLI
- Fix some unit tests inconsistency (with the runInBand option)