### PR TITLE
Refactoring: use payment helper functions to avoid duplicate code

### DIFF
--- a/viv-wallet-app/src/App.vue
+++ b/viv-wallet-app/src/App.vue
@@ -88,7 +88,6 @@ export default defineComponent({
 html,
 body {
     height: 100%;
-    box-sizing: content-box;
 }
 
 .content {

--- a/viv-wallet-app/src/components/ActionHistory.vue
+++ b/viv-wallet-app/src/components/ActionHistory.vue
@@ -54,7 +54,8 @@
 
 <script lang="ts">
 import { defineComponent, PropType } from "vue";
-import { ActionForHistory, PaymentStatus } from "../models/action";
+import paymentHelpers from "@/utils/paymentHelpers";
+import { ActionForHistory } from "../models/action";
 import FilterInput from "./FilterInput.vue";
 import StatusBadge from "./StatusBadge.vue";
 
@@ -81,27 +82,7 @@ export default defineComponent({
         },
     },
     methods: {
-        isPaymentPaid(action: ActionForHistory) {
-            return action.status === PaymentStatus.Paid;
-        },
-        formatPaymentStatus(status: PaymentStatus) {
-            switch (status) {
-                case PaymentStatus.Paid:
-                    return "Débloqué";
-                case PaymentStatus.Unpaid:
-                default:
-                    return "Non débloqué";
-            }
-        },
-        getPaymentStatusType(status: PaymentStatus) {
-            switch (status) {
-                case PaymentStatus.Paid:
-                    return "green";
-                case PaymentStatus.Unpaid:
-                default:
-                    return "red";
-            }
-        },
+        ...paymentHelpers,
     },
 });
 </script>

--- a/viv-wallet-app/src/components/ActionsBlock.vue
+++ b/viv-wallet-app/src/components/ActionsBlock.vue
@@ -49,7 +49,8 @@
 
 <script lang="ts">
 import { defineComponent, PropType } from "vue";
-import { Action, PaymentStatus } from "../models/action";
+import paymentHelpers from "@/utils/paymentHelpers";
+import { Action } from "../models/action";
 import StatusBadge from "./StatusBadge.vue";
 
 export default defineComponent({
@@ -62,29 +63,7 @@ export default defineComponent({
         },
     },
     methods: {
-        isPaymentPaid(action: Action) {
-            return action.status === PaymentStatus.Paid;
-        },
-
-        formatPaymentStatus(status: PaymentStatus) {
-            switch (status) {
-                case PaymentStatus.Paid:
-                    return "Débloqué";
-                case PaymentStatus.Unpaid:
-                default:
-                    return "Non débloqué";
-            }
-        },
-
-        getPaymentStatusType(status: PaymentStatus) {
-            switch (status) {
-                case PaymentStatus.Paid:
-                    return "green";
-                case PaymentStatus.Unpaid:
-                default:
-                    return "red";
-            }
-        },
+        ...paymentHelpers,
     },
 });
 </script>

--- a/viv-wallet-app/src/utils/paymentHelpers.ts
+++ b/viv-wallet-app/src/utils/paymentHelpers.ts
@@ -1,0 +1,29 @@
+import { ActionForHistory, PaymentStatus } from "@/models/action";
+
+export function isPaymentPaid(action: ActionForHistory) {
+    return action.status === PaymentStatus.Paid;
+}
+export function formatPaymentStatus(status: PaymentStatus) {
+    switch (status) {
+        case PaymentStatus.Paid:
+            return "Débloqué";
+        case PaymentStatus.Unpaid:
+        default:
+            return "Non débloqué";
+    }
+}
+export function getPaymentStatusType(status: PaymentStatus) {
+    switch (status) {
+        case PaymentStatus.Paid:
+            return "green";
+        case PaymentStatus.Unpaid:
+        default:
+            return "red";
+    }
+}
+
+export default {
+    isPaymentPaid,
+    formatPaymentStatus,
+    getPaymentStatusType,
+};

--- a/viv-wallet-app/src/views/Payment.vue
+++ b/viv-wallet-app/src/views/Payment.vue
@@ -106,8 +106,9 @@
 
 <script lang="ts">
 import { defineComponent } from "vue";
-import { Action, PaymentStatus } from "@/models/action";
+import { Action } from "@/models/action";
 import { UsersService } from "@/services/users";
+import paymentHelpers from "@/utils/paymentHelpers";
 import BalanceCard from "../components/BalanceCard.vue";
 import Checkbox from "../components/Checkbox.vue";
 import Illustration from "../components/Illustration.vue";
@@ -193,6 +194,7 @@ export default defineComponent({
         }
     },
     methods: {
+        ...paymentHelpers,
         formatConsultantStatus(status?: keyof typeof ConsultantStatus) {
             if (status) {
                 return toString(ConsultantStatus[status]);
@@ -216,29 +218,6 @@ export default defineComponent({
                 this.errored = true;
             } finally {
                 this.loading = false;
-            }
-        },
-        isPaymentPaid(action: Action) {
-            return action.status === PaymentStatus.Paid;
-        },
-
-        formatPaymentStatus(status: PaymentStatus) {
-            switch (status) {
-                case PaymentStatus.Paid:
-                    return "Débloqué";
-                case PaymentStatus.Unpaid:
-                default:
-                    return "Non débloqué";
-            }
-        },
-
-        getPaymentStatusType(status: PaymentStatus) {
-            switch (status) {
-                case PaymentStatus.Paid:
-                    return "green";
-                case PaymentStatus.Unpaid:
-                default:
-                    return "red";
             }
         },
     },


### PR DESCRIPTION
- Remove duplicate code
- Use helper functions instead of mixins. Mixins are considered an anti-pattern. In Vue 3, we prefer using composition APIs and helpers.