### PR TITLE
Update azure cli orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-    azure-cli: circleci/azure-cli@1.1.0
+    azure-cli: circleci/azure-cli@1.2.0
     helm: circleci/helm@0.2.3
     docker: circleci/docker@1.5.0
 


### PR DESCRIPTION
The current version crashes when it tries to install the azure-cli docker image on Circleci.
The new version of the orb fixes this issue (tested on x4b-deploy and AC2).